### PR TITLE
Fixed NPM List Command to avoid errors

### DIFF
--- a/src/packages/npm.ts
+++ b/src/packages/npm.ts
@@ -1,19 +1,19 @@
-import execa from "execa";
-import which from "which";
-import { IPackage, IPackageManager } from "./interface";
+import execa from 'execa';
+import which from 'which';
+import { IPackage, IPackageManager } from './interface';
 
 export class PackageManagerNPM implements IPackageManager {
   get name() {
-    return "npm";
+    return 'npm';
   }
 
   get system(): NodeJS.Platform[] {
-    return ["win32", "linux", "darwin"];
+    return ['win32', 'linux', 'darwin'];
   }
 
   public async detect(): Promise<boolean> {
     try {
-      await which("npm");
+      await which('npm');
       return true;
     } catch (err) {
       return false;
@@ -21,7 +21,7 @@ export class PackageManagerNPM implements IPackageManager {
   }
 
   public async version(): Promise<string> {
-    const ps = await execa("npm", ["-v"]);
+    const ps = await execa('npm', ['-v']);
 
     return ps.stdout.trim();
   }
@@ -41,7 +41,7 @@ export class PackageManagerNPM implements IPackageManager {
       [packageName: string]: NPMPackage;
     }
 
-    const ps = await execa("npm", ["list", "-g", "--json", "--depth=1"]);
+    const ps = await execa('npm', ['list', '-g', '--json', '--depth 0']);
 
     const dependencies = (JSON.parse(ps.stdout) as { dependencies: Dependency }).dependencies;
 
@@ -56,7 +56,7 @@ export class PackageManagerNPM implements IPackageManager {
         package: this.name,
         name: depName,
         version: dep.version,
-        desc: "",
+        desc: '',
       });
     }
 
@@ -64,7 +64,7 @@ export class PackageManagerNPM implements IPackageManager {
   }
 
   public async install(packageName: string, version: string): Promise<string> {
-    return `npm install ${packageName + (version ? `@${version}` : "")} -g`;
+    return `npm install ${packageName + (version ? `@${version}` : '')} -g`;
   }
 
   public async uninstall(packageName: string, oldVersion: string): Promise<string> {
@@ -72,6 +72,6 @@ export class PackageManagerNPM implements IPackageManager {
   }
 
   public async update(packageName: string, oldVersion: string, newVersion: string): Promise<string> {
-    return `npm update ${packageName + (newVersion ? `@${newVersion}` : "")} -g`;
+    return `npm update ${packageName + (newVersion ? `@${newVersion}` : '')} -g`;
   }
 }


### PR DESCRIPTION
# Problem
This command on `line:44 - npm.ts` throws errors if invalid dependencies are found.

```bash
npm list -g --json --depth=1
```

![error](https://user-images.githubusercontent.com/18057996/174576547-772e4f94-a3fe-4ed2-a0b1-c5fa57125cc4.png)

# Empty NPM List

![Code_6xhNnAI2Ep](https://user-images.githubusercontent.com/18057996/174575816-d39b5e2d-cf70-421e-8361-2f4cb0cae2dc.png)

# Error

```bash
Command failed with exit code 1: npm list -g --json --depth=1
npm ERR! code ELSPROBLEMS
npm ERR! invalid: cors@2.8.5 C:\Users\Shivam\AppData\Roaming\nvm\v18.4.0\node_modules\live-server\node_modules\cors
npm ERR! invalid: object-assign@4.1.1 C:\Users\Shivam\AppData\Roaming\nvm\v18.4.0\node_modules\live-server\node_modules\object-assign
npm ERR! invalid: opn@6.0.0 C:\Users\Shivam\AppData\Roaming\nvm\v18.4.0\node_modules\live-server\node_modules\opn
npm ERR! invalid: proxy-middleware@0.15.0 C:\Users\Shivam\AppData\Roaming\nvm\v18.4.0\node_modules\live-server\node_modules\proxy-middleware
npm ERR! invalid: send@0.18.0 C:\Users\Shivam\AppData\Roaming\nvm\v18.4.0\node_modules\live-server\node_modules\send
npm ERR! missing: react-dom@>=16.8, required by react-router-dom@6.3.0
npm ERR! missing: react@>=16.8, required by react-router-dom@6.3.0
```

# Solution
```bash
npm list -g --json --depth 0
```
This depth will return packages installed while also avoiding those error thrown in the json.

# After Solution

![Code_mrHSi43RJo](https://user-images.githubusercontent.com/18057996/174576590-2ec68183-3983-41d0-8eb5-e8a72ca7cf57.png)

